### PR TITLE
Fix NSPopover auto-close behavior in menu bar app with reliable focus and event handling

### DIFF
--- a/Sources/MenuBarContentView.swift
+++ b/Sources/MenuBarContentView.swift
@@ -24,7 +24,7 @@ struct MenuBarContentView: View {
                 Button(action: {
                     NSApp.terminate(nil)
                 }) {
-                    HStack {
+                    HStack(spacing: 6) {
                         Image(systemName: "power")
                             .font(.system(size: 13, weight: .bold))
                         Text("Quit TabLift")

--- a/Sources/MenuBarContentView.swift
+++ b/Sources/MenuBarContentView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct MenuBarContentView: View {
+    @AppStorage(WindowManager.restoreAllKey) var restoreAllWindows: Bool = true
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("TabLift")
+                .font(.headline)
+            Divider()
+            Toggle(isOn: $restoreAllWindows) {
+                Text("Restore all minimized windows")
+            }
+            .toggleStyle(SwitchToggleStyle())
+
+            Button("Open Settings") {
+                NSApp.sendAction(#selector(AppDelegate.showUI), to: nil, from: nil)
+            }
+
+            WavyDivider()
+
+            HStack {
+                Spacer()
+                Button(action: {
+                    NSApp.terminate(nil)
+                }) {
+                    HStack {
+                        Image(systemName: "power")
+                            .font(.system(size: 13, weight: .bold))
+                        Text("Quit TabLift")
+                            .font(.footnote)
+                            .fontWeight(.medium)
+                    }
+                    .foregroundColor(.red)
+                    .padding(.vertical, 7)
+                    .padding(.horizontal, 18)
+                }
+                .buttonStyle(PlainButtonStyle())
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}
+
+struct WavyDivider: View {
+    var amplitude: CGFloat = 4
+    var waveLength: CGFloat = 24
+    var color: Color = .secondary
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            let height = geo.size.height
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: height / 2))
+                var x: CGFloat = 0
+                while x <= width {
+                    let y = height / 2 + amplitude * sin((2 * .pi / waveLength) * x)
+                    path.addLine(to: CGPoint(x: x, y: y))
+                    x += 1
+                }
+            }
+            .stroke(color, style: StrokeStyle(lineWidth: 1.4, lineCap: .round))
+        }
+        .frame(height: amplitude * 2 + 4)
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/MenuBarManager.swift
+++ b/Sources/MenuBarManager.swift
@@ -37,7 +37,7 @@ class MenuBarManager: NSObject {
         }
     }
 
-    @objc private func togglePopover(_ sender: Any?) {
+    @objc private func togglePopover(_ sender: AnyObject?) {
         guard let button = statusItem?.button, let popover else { return }
 
         if popover.isShown {

--- a/Sources/MenuBarManager.swift
+++ b/Sources/MenuBarManager.swift
@@ -44,10 +44,9 @@ class MenuBarManager: NSObject {
             popover.performClose(sender)
             removeEventMonitor()
         } else {
-            NSApp.activate(ignoringOtherApps: true) // 🧠 Ensure app is frontmost
+            NSApp.activate(ignoringOtherApps: true)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             
-            // 🧠 Critical to make popover's window key so transient works
             popover.contentViewController?.view.window?.makeKey()
 
             startEventMonitor()

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		BE83CD402E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */; };
 		BE83CD422E0EDC8600DF73E8 /* HyperLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD412E0EDC8600DF73E8 /* HyperLink.swift */; };
 		BE83CD462E0EDD2800DF73E8 /* NSWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD452E0EDD2800DF73E8 /* NSWindow.swift */; };
+		BEB9B6592E2F523E00A7456D /* MenuBarContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB9B6582E2F523E00A7456D /* MenuBarContentView.swift */; };
 		BEE1EC4D2E062CD500D8CE5F /* AppMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE1EC482E062CD500D8CE5F /* AppMonitor.swift */; };
 		BEE1EC4F2E062CD500D8CE5F /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE1EC4B2E062CD500D8CE5F /* WindowManager.swift */; };
 		BEE1EC502E062CD500D8CE5F /* TabLiftApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE1EC4A2E062CD500D8CE5F /* TabLiftApp.swift */; };
@@ -46,6 +47,7 @@
 		BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionView.swift; sourceTree = "<group>"; };
 		BE83CD412E0EDC8600DF73E8 /* HyperLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperLink.swift; sourceTree = "<group>"; };
 		BE83CD452E0EDD2800DF73E8 /* NSWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSWindow.swift; sourceTree = "<group>"; };
+		BEB9B6582E2F523E00A7456D /* MenuBarContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContentView.swift; sourceTree = "<group>"; };
 		BEBC5E4A2E05826B004B38DB /* TabLift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TabLift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEE1EC452E062CD500D8CE5F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BEE1EC462E062CD500D8CE5F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				BEE1EC4B2E062CD500D8CE5F /* WindowManager.swift */,
 				BE1AF6692E1315D400DB8C44 /* CmdBacktickMonitor.swift */,
 				BE1AF66B2E131C5F00DB8C44 /* MenuBarManager.swift */,
+				BEB9B6582E2F523E00A7456D /* MenuBarContentView.swift */,
 				BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */,
 				BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */,
 				BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */,
@@ -202,6 +205,7 @@
 				BE83CD422E0EDC8600DF73E8 /* HyperLink.swift in Sources */,
 				BE1AF66C2E131C5F00DB8C44 /* MenuBarManager.swift in Sources */,
 				BEE1EC4F2E062CD500D8CE5F /* WindowManager.swift in Sources */,
+				BEB9B6592E2F523E00A7456D /* MenuBarContentView.swift in Sources */,
 				BE1AF66A2E1315D600DB8C44 /* CmdBacktickMonitor.swift in Sources */,
 				BE5209C62E117A010048CC49 /* CheckForUpdates.swift in Sources */,
 				BEE1EC502E062CD500D8CE5F /* TabLiftApp.swift in Sources */,


### PR DESCRIPTION
Fixes #13 
This commit fixes the issue where the NSPopover does not close automatically when clicking outside of it in a macOS menu bar app. The popover behavior is set to .transient to enable auto-closing, and the application is activated before showing the popover to ensure it receives proper focus. Additionally, the popover’s window is forced to become key immediately after being shown, which helps in detecting clicks outside and closing the popover reliably. A global event monitor is also added as a fallback to listen for mouse clicks outside the popover and close it accordingly.