### PR TITLE
Fixed #28, #23. The previous version created windows for apps that weren't headless. Restore minimized app in the current Space.

### DIFF
--- a/Sources/WindowManager.swift
+++ b/Sources/WindowManager.swift
@@ -1,93 +1,135 @@
 import Cocoa
+import ApplicationServices
 
 class WindowManager {
-    static let restoreAllKey = "restoreAllWindows"
-    static let openWindowKey = "openNewWindow"
+    static let restoreAllKey             = "restoreAllWindows"
+    static let openWindowKey             = "openNewWindow"
     static let minimizePreviousWindowKey = "minimizePreviousWindow"
+
+    static func checkForWindows(current: NSRunningApplication, previous: NSRunningApplication?) {
+        let openNew   = UserDefaults.standard.bool(forKey: openWindowKey)
+        let minimize  = UserDefaults.standard.bool(forKey: minimizePreviousWindowKey)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            if openNew && !hasAnyPracticalVisibleWindow(for: current) {
+                openNewWindowApp(for: current)
+                return
+            }
+
+            if minimize, let prev = previous {
+                minimizeFocusedWindow(of: prev)
+            }
+            restoreMinimizedWindows(for: current)
+        }
+    }
+
+    private static func hasAnyPracticalVisibleWindow(for app: NSRunningApplication) -> Bool {
+        if hasAXVisibleWindow(for: app) { return true }
+        if hasCGVisibleWindow(for: app) { return true }
+        return false
+    }
+
+    private static func hasAXVisibleWindow(for app: NSRunningApplication) -> Bool {
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        if AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) != .success {
+            return false
+        }
+        guard let windows = raw as? [AXUIElement] else { return false }
+        for window in windows {
+            var minRaw: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+               let isMin = minRaw as? Bool, isMin {
+                continue
+            }
+            var posRaw: AnyObject?
+            var sizeRaw: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRaw) == .success,
+               AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRaw) == .success {
+                let pos = posRaw as! AXValue
+                let size = sizeRaw as! AXValue
+                var position: CGPoint = .zero
+                var sz: CGSize = .zero
+                if AXValueGetType(pos) == .cgPoint,
+                   AXValueGetType(size) == .cgSize,
+                   AXValueGetValue(pos, .cgPoint, &position),
+                   AXValueGetValue(size, .cgSize, &sz),
+                   sz.width > 100, sz.height > 100
+                {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static func hasCGVisibleWindow(for app: NSRunningApplication) -> Bool {
+        guard let bundleID = app.bundleIdentifier else { return false }
+        let appProcs = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        let pids = Set(appProcs.map { $0.processIdentifier })
+
+        guard let infoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        for dict in infoList {
+            guard
+                let ownerPID = dict[kCGWindowOwnerPID as String] as? pid_t,
+                pids.contains(ownerPID),
+                let layer = dict[kCGWindowLayer as String] as? Int, layer == 0,
+                let bounds = dict[kCGWindowBounds as String] as? [String: Any],
+                let width  = bounds["Width"]  as? CGFloat, width  > 100,
+                let height = bounds["Height"] as? CGFloat, height > 100,
+                let alpha = dict[kCGWindowAlpha as String] as? CGFloat, alpha > 0.05
+            else { continue }
+            return true
+        }
+        return false
+    }
 
     static func restoreMinimizedWindows(for app: NSRunningApplication) {
         let restoreAll = UserDefaults.standard.bool(forKey: restoreAllKey)
-        let appElement = AXUIElementCreateApplication(app.processIdentifier)
-        var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-              let windows = value as? [AXUIElement] else { return }
-
-        if restoreAll {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                }
-            }
-        } else {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                    break
-                }
-            }
+        let appEl      = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        guard AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) == .success,
+              let windows = raw as? [AXUIElement] else {
+            return
+        }
+        for win in windows {
+            var minRaw: AnyObject?
+            guard AXUIElementCopyAttributeValue(win, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+                  let isMin = minRaw as? Bool, isMin else { continue }
+            AXUIElementSetAttributeValue(win, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+            if !restoreAll { break }
         }
     }
 
     static func minimizeFocusedWindow(of app: NSRunningApplication) {
-        let appElement = AXUIElementCreateApplication(app.processIdentifier)
         let restoreAll = UserDefaults.standard.bool(forKey: restoreAllKey)
-        var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-              let windows = value as? [AXUIElement] else { return }
-        if restoreAll {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   !isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-                }
-            }
-        }else{
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   !isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-                    break
-                }
-            }
+        let appEl      = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        guard AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) == .success,
+              let windows = raw as? [AXUIElement] else {
+            return
         }
-    }
-
-    static func checkForWindows(current: NSRunningApplication, previous: NSRunningApplication?){
-        let openNewWindow = UserDefaults.standard.bool(forKey: openWindowKey)
-        let minimizePreviousWindow = UserDefaults.standard.bool(forKey: minimizePreviousWindowKey)
-        if openNewWindow {
-            let appElement = AXUIElementCreateApplication(current.processIdentifier)
-            var value: AnyObject?
-            if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-               let windows = value as? [AXUIElement],
-               windows.isEmpty {
-                openNewWindowApp(for: current)
-                return
-            }
+        for win in windows {
+            var minRaw: AnyObject?
+            guard AXUIElementCopyAttributeValue(win, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+                  let isMin = minRaw as? Bool, !isMin else { continue }
+            AXUIElementSetAttributeValue(win, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+            if !restoreAll { break }
         }
-        if minimizePreviousWindow, let previous = previous {
-            minimizeFocusedWindow(of: previous)
-        }
-        restoreMinimizedWindows(for: current)
     }
 
     private static func openNewWindowApp(for app: NSRunningApplication) {
         app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
-        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x2D, keyDown: true)
-        keyDown?.flags = .maskCommand
-        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x2D, keyDown: false)
-        keyUp?.flags = .maskCommand
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
+        let keyCode: CGKeyCode = 0x2D
+        guard let src = CGEventSource(stateID: .hidSystemState) else { return }
+        let down = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true)!
+        down.flags = .maskCommand
+        let up   = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)!
+        up.flags = .maskCommand
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
     }
 }

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -371,7 +371,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -402,7 +402,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -425,7 +425,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Fixes #28 
Fixes #23 