### PR TITLE
Fix #21 - New Feature: DockClick minimizes app window

### DIFF
--- a/Sources/DockClickMonitor.swift
+++ b/Sources/DockClickMonitor.swift
@@ -1,0 +1,180 @@
+import Cocoa
+import ApplicationServices
+
+class DockClickMonitor {
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // Track the number of Dock clicks for each app (by pid)
+    private var appClickCounts: [pid_t: Int] = [:]
+    // Remember when we last saw the app become frontmost (for alt-tab etc)
+    private var lastFrontmostAppPID: pid_t?
+    private var lastFrontmostAppChange: Date?
+
+    // Main event observer for app switches (alt-tab, click, etc)
+    private var workspaceObserver: NSObjectProtocol?
+
+    init() {
+        setupEventTap()
+        setupFrontmostAppObserver()
+    }
+
+    deinit {
+        if let eventTap = eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: false)
+            CFMachPortInvalidate(eventTap)
+        }
+        if let runLoopSource = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        }
+        if let observer = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    private func setupEventTap() {
+        let eventMask = (1 << CGEventType.leftMouseDown.rawValue)
+        let callback: CGEventTapCallBack = { _, _, event, userInfo in
+            guard let userInfo = userInfo else { return Unmanaged.passUnretained(event) }
+            let monitor = Unmanaged<DockClickMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+            monitor.handleClick(event: event)
+            return Unmanaged.passUnretained(event)
+        }
+        let pointer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        guard let eventTap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .tailAppendEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: callback,
+            userInfo: pointer
+        ) else {
+            print("Failed to create DockClickMonitor event tap")
+            return
+        }
+        self.eventTap = eventTap
+        let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        self.runLoopSource = runLoopSource
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+    }
+
+    private func setupFrontmostAppObserver() {
+        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notif in
+            guard let self = self,
+                  let userInfo = notif.userInfo,
+                  let app = userInfo[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            else { return }
+            let pid = app.processIdentifier
+            self.lastFrontmostAppPID = pid
+            self.lastFrontmostAppChange = Date()
+            // Reset click count for this app, so a Dock click (if any) will be counted as the first
+            self.appClickCounts[pid] = 1
+        }
+    }
+
+    private func handleClick(event: CGEvent) {
+        let mouseLocation = NSEvent.mouseLocation
+        guard let dockApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.dock").first else { return }
+        let dockElement = AXUIElementCreateApplication(dockApp.processIdentifier)
+
+        var children: AnyObject?
+        if AXUIElementCopyAttributeValue(dockElement, kAXChildrenAttribute as CFString, &children) != .success { return }
+        guard let dockChildren = children as? [AXUIElement], !dockChildren.isEmpty else { return }
+
+        // Look for AXList element
+        guard let axList = dockChildren.first(where: {
+            (try? $0.role() == kAXListRole) ?? false
+        }) else { return }
+
+        var dockItems: AnyObject?
+        if AXUIElementCopyAttributeValue(axList, kAXChildrenAttribute as CFString, &dockItems) != .success { return }
+        guard let dockIcons = dockItems as? [AXUIElement] else { return }
+
+        // Get the main screen's height (for y flip)
+        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+
+        for icon in dockIcons {
+            if (try? icon.subrole()) != "AXApplicationDockItem" { continue }
+
+            var positionValue: AnyObject?
+            var sizeValue: AnyObject?
+            if AXUIElementCopyAttributeValue(icon, kAXPositionAttribute as CFString, &positionValue) != .success { continue }
+            if AXUIElementCopyAttributeValue(icon, kAXSizeAttribute as CFString, &sizeValue) != .success { continue }
+            let position = positionValue as! AXValue
+            let size = sizeValue as! AXValue
+
+            var pos = CGPoint.zero, sz = CGSize.zero
+            AXValueGetValue(position, .cgPoint, &pos)
+            AXValueGetValue(size, .cgSize, &sz)
+
+            // --- Correct the coordinate system: ---
+            // AX origin is top-left, NSEvent is bottom-left, so flip y
+            let correctedY = screenHeight - pos.y - sz.height
+            let correctedFrame = CGRect(x: pos.x, y: correctedY, width: sz.width, height: sz.height)
+            // --------------------------------------
+
+            if correctedFrame.contains(mouseLocation) {
+                // This is the clicked Dock icon!
+                var bundleURL: AnyObject?
+                if AXUIElementCopyAttributeValue(icon, kAXURLAttribute as CFString, &bundleURL) == .success,
+                   let url = bundleURL as? NSURL,
+                   let bundle = Bundle(url: url as URL),
+                   let bundleID = bundle.bundleIdentifier,
+                   let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first
+                {
+                    let pid = app.processIdentifier
+
+                    // If the app is not frontmost, set click count to 1 (simulate first click after switch)
+                    if pid != NSWorkspace.shared.frontmostApplication?.processIdentifier {
+                        appClickCounts[pid] = 1
+                    } else {
+                        // Increment click count for this app
+                        let newCount = (appClickCounts[pid] ?? 0) + 1
+                        appClickCounts[pid] = newCount
+
+
+                        // Only minimize if app is frontmost, with a delay, and the click count is even
+                        if newCount % 2 == 0 {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                                WindowManager.minimizeFocusedWindow(of: app)
+                            }
+                        }
+                    }
+                } else if let title = try? icon.title(),
+                          let app = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == title }) {
+                }
+                break
+            }
+        }
+    }
+}
+
+// Accessibility helpers
+private extension AXUIElement {
+    func role() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXRoleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func subrole() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXSubroleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func title() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXTitleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+}

--- a/Sources/DockClickMonitor.swift
+++ b/Sources/DockClickMonitor.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import ApplicationServices
+import SwiftUI
 
 class DockClickMonitor {
     private var eventTap: CFMachPort?
@@ -119,7 +120,6 @@ class DockClickMonitor {
             // --------------------------------------
 
             if correctedFrame.contains(mouseLocation) {
-                // This is the clicked Dock icon!
                 var bundleURL: AnyObject?
                 if AXUIElementCopyAttributeValue(icon, kAXURLAttribute as CFString, &bundleURL) == .success,
                    let url = bundleURL as? NSURL,
@@ -137,16 +137,14 @@ class DockClickMonitor {
                         let newCount = (appClickCounts[pid] ?? 0) + 1
                         appClickCounts[pid] = newCount
 
-
                         // Only minimize if app is frontmost, with a delay, and the click count is even
                         if newCount % 2 == 0 {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                                // Use user preference for all windows or just focused
                                 WindowManager.minimizeFocusedWindow(of: app)
                             }
                         }
                     }
-                } else if let title = try? icon.title(),
-                          let app = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == title }) {
                 }
                 break
             }

--- a/Sources/TabLiftApp.swift
+++ b/Sources/TabLiftApp.swift
@@ -18,7 +18,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var cmdBacktickMonitor: CmdBacktickMonitor?
     var window: NSWindow?
     private let autoUpdateManager = AutoUpdateManager.shared
-
+    
+    var dockClickMonitor: DockClickMonitor?
+    
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: [
             "showMenuBarIcon": true,
@@ -44,7 +46,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         appMonitor = AppMonitor()
         appMonitor?.setupEventTap()
         registerLoginItemIfNeeded()
-
+        
+        dockClickMonitor = DockClickMonitor()
+        
         let showMenuBar = UserDefaults.standard.bool(forKey: "showMenuBarIcon")
         MenuBarManager.shared.showMenuBarIcon(show: showMenuBar)
     }

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -375,7 +375,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -406,7 +406,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -429,7 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BE5209D92E1185CF0048CC49 /* FormViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209D82E1185CF0048CC49 /* FormViewModifier.swift */; };
 		BE5209E92E1189E80048CC49 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209E82E1189E80048CC49 /* SettingsView.swift */; };
 		BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209EA2E11A1270048CC49 /* TabLift.swift */; };
+		BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */; };
 		BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */; };
 		BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */; };
 		BE83CD402E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */; };
@@ -42,6 +43,7 @@
 		BE5209E82E1189E80048CC49 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		BE5209EA2E11A1270048CC49 /* TabLift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLift.swift; sourceTree = "<group>"; };
 		BE5209EC2E11A2FD0048CC49 /* TabLift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TabLift.entitlements; sourceTree = "<group>"; };
+		BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockClickMonitor.swift; sourceTree = "<group>"; };
 		BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermission.swift; sourceTree = "<group>"; };
 		BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionWindow.swift; sourceTree = "<group>"; };
 		BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 		BEE1EC4C2E062CD500D8CE5F /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */,
 				BE5209C52E1179FB0048CC49 /* CheckForUpdates.swift */,
 				BE5209E82E1189E80048CC49 /* SettingsView.swift */,
 				BEE1EC482E062CD500D8CE5F /* AppMonitor.swift */,
@@ -209,6 +212,7 @@
 				BE1AF66A2E1315D600DB8C44 /* CmdBacktickMonitor.swift in Sources */,
 				BE5209C62E117A010048CC49 /* CheckForUpdates.swift in Sources */,
 				BEE1EC502E062CD500D8CE5F /* TabLiftApp.swift in Sources */,
+				BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */,
 				BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */,
 				BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */,
 				BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */,


### PR DESCRIPTION
Fixes #21 
This pull request introduces a new feature to monitor and handle Dock clicks, along with some project configuration updates. The most important changes include the addition of the `DockClickMonitor` class, integration of this monitor into the app lifecycle, and version updates in the project settings.

### New Feature: DockClickMonitor

* **`DockClickMonitor` class implementation**: Added a new class in `DockClickMonitor.swift` to monitor Dock clicks and manage app-specific behaviors, such as minimizing windows on alternate clicks. This includes setting up event taps, observing frontmost app changes, and handling accessibility interactions with Dock icons.
* **Integration into `AppDelegate`**: Introduced a `dockClickMonitor` property in `AppDelegate` and initialized it during app launch to enable Dock click monitoring. [[1]](diffhunk://#diff-31979b7cbe157cea4c36d3e321dfc8654a888d7dc93ef57f46e1e0f10c4efdd7R22-R23) [[2]](diffhunk://#diff-31979b7cbe157cea4c36d3e321dfc8654a888d7dc93ef57f46e1e0f10c4efdd7R50-R51)

These changes collectively enhance the application's functionality by adding Dock click monitoring and ensure the project configuration aligns with the new feature.