### PR TITLE
Dev/v1.8

### DIFF
--- a/Sources/AXUIElement+Helpers.swift
+++ b/Sources/AXUIElement+Helpers.swift
@@ -1,0 +1,25 @@
+import Cocoa
+
+extension AXUIElement {
+    func role() -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXRoleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func subrole() -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXSubroleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func title() -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXTitleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+}

--- a/Sources/DockClickMonitor.swift
+++ b/Sources/DockClickMonitor.swift
@@ -1,0 +1,178 @@
+import Cocoa
+import ApplicationServices
+import SwiftUI
+
+class DockClickMonitor {
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // Track the number of Dock clicks for each app (by pid)
+    private var appClickCounts: [pid_t: Int] = [:]
+    // Remember when we last saw the app become frontmost (for alt-tab etc)
+    private var lastFrontmostAppPID: pid_t?
+    private var lastFrontmostAppChange: Date?
+
+    // Main event observer for app switches (alt-tab, click, etc)
+    private var workspaceObserver: NSObjectProtocol?
+
+    init() {
+        setupEventTap()
+        setupFrontmostAppObserver()
+    }
+
+    deinit {
+        if let eventTap = eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: false)
+            CFMachPortInvalidate(eventTap)
+        }
+        if let runLoopSource = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        }
+        if let observer = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    private func setupEventTap() {
+        let eventMask = (1 << CGEventType.leftMouseDown.rawValue)
+        let callback: CGEventTapCallBack = { _, _, event, userInfo in
+            guard let userInfo = userInfo else { return Unmanaged.passUnretained(event) }
+            let monitor = Unmanaged<DockClickMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+            monitor.handleClick(event: event)
+            return Unmanaged.passUnretained(event)
+        }
+        let pointer = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        guard let eventTap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .tailAppendEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: callback,
+            userInfo: pointer
+        ) else {
+            print("Failed to create DockClickMonitor event tap")
+            return
+        }
+        self.eventTap = eventTap
+        let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+        self.runLoopSource = runLoopSource
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+    }
+
+    private func setupFrontmostAppObserver() {
+        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notif in
+            guard let self = self,
+                  let userInfo = notif.userInfo,
+                  let app = userInfo[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            else { return }
+            let pid = app.processIdentifier
+            self.lastFrontmostAppPID = pid
+            self.lastFrontmostAppChange = Date()
+            // Reset click count for this app, so a Dock click (if any) will be counted as the first
+            self.appClickCounts[pid] = 1
+        }
+    }
+
+    private func handleClick(event: CGEvent) {
+        let mouseLocation = NSEvent.mouseLocation
+        guard let dockApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.dock").first else { return }
+        let dockElement = AXUIElementCreateApplication(dockApp.processIdentifier)
+
+        var children: AnyObject?
+        if AXUIElementCopyAttributeValue(dockElement, kAXChildrenAttribute as CFString, &children) != .success { return }
+        guard let dockChildren = children as? [AXUIElement], !dockChildren.isEmpty else { return }
+
+        // Look for AXList element
+        guard let axList = dockChildren.first(where: {
+            (try? $0.role() == kAXListRole) ?? false
+        }) else { return }
+
+        var dockItems: AnyObject?
+        if AXUIElementCopyAttributeValue(axList, kAXChildrenAttribute as CFString, &dockItems) != .success { return }
+        guard let dockIcons = dockItems as? [AXUIElement] else { return }
+
+        // Get the main screen's height (for y flip)
+        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+
+        for icon in dockIcons {
+            if (try? icon.subrole()) != "AXApplicationDockItem" { continue }
+
+            var positionValue: AnyObject?
+            var sizeValue: AnyObject?
+            if AXUIElementCopyAttributeValue(icon, kAXPositionAttribute as CFString, &positionValue) != .success { continue }
+            if AXUIElementCopyAttributeValue(icon, kAXSizeAttribute as CFString, &sizeValue) != .success { continue }
+            let position = positionValue as! AXValue
+            let size = sizeValue as! AXValue
+
+            var pos = CGPoint.zero, sz = CGSize.zero
+            AXValueGetValue(position, .cgPoint, &pos)
+            AXValueGetValue(size, .cgSize, &sz)
+
+            // --- Correct the coordinate system: ---
+            // AX origin is top-left, NSEvent is bottom-left, so flip y
+            let correctedY = screenHeight - pos.y - sz.height
+            let correctedFrame = CGRect(x: pos.x, y: correctedY, width: sz.width, height: sz.height)
+            // --------------------------------------
+
+            if correctedFrame.contains(mouseLocation) {
+                var bundleURL: AnyObject?
+                if AXUIElementCopyAttributeValue(icon, kAXURLAttribute as CFString, &bundleURL) == .success,
+                   let url = bundleURL as? NSURL,
+                   let bundle = Bundle(url: url as URL),
+                   let bundleID = bundle.bundleIdentifier,
+                   let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first
+                {
+                    let pid = app.processIdentifier
+
+                    // If the app is not frontmost, set click count to 1 (simulate first click after switch)
+                    if pid != NSWorkspace.shared.frontmostApplication?.processIdentifier {
+                        appClickCounts[pid] = 1
+                    } else {
+                        // Increment click count for this app
+                        let newCount = (appClickCounts[pid] ?? 0) + 1
+                        appClickCounts[pid] = newCount
+
+                        // Only minimize if app is frontmost, with a delay, and the click count is even
+                        if newCount % 2 == 0 {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                                // Use user preference for all windows or just focused
+                                WindowManager.minimizeFocusedWindow(of: app)
+                            }
+                        }
+                    }
+                }
+                break
+            }
+        }
+    }
+}
+
+// Accessibility helpers
+private extension AXUIElement {
+    func role() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXRoleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func subrole() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXSubroleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+    func title() throws -> String? {
+        var value: AnyObject?
+        if AXUIElementCopyAttributeValue(self, kAXTitleAttribute as CFString, &value) == .success {
+            return value as? String
+        }
+        return nil
+    }
+}

--- a/Sources/DockIconHoverMonitor.swift
+++ b/Sources/DockIconHoverMonitor.swift
@@ -1,0 +1,334 @@
+import Cocoa
+import SwiftUI
+import ApplicationServices
+
+class DockIconHoverMonitor {
+    private var axObserver: AXObserver?
+    private var dockPID: pid_t = 0
+    private var previewPanel: NSPanel?
+    private var hostingView: NSHostingView<DockPreviewPanel>?
+    private var lastBundleIdentifier: String?
+    private var lastPanelFrame: CGRect?
+    private var clickMonitor: Any?
+    private var mouseTimer: Timer?
+    private var dockFrame: CGRect = .zero
+    private var lastIconFrame: CGRect?
+
+    // Need access to DockClickMonitor (singleton or pass in)
+    private var dockClickMonitor: DockClickMonitor? {
+        (NSApplication.shared.delegate as? AppDelegate)?.dockClickMonitor
+    }
+
+    init() {
+        guard AXIsProcessTrusted() else {
+            NSLog("Accessibility permissions NOT granted. Dock popups will not work.")
+            return
+        }
+        setupDockObserver()
+        updateDockFrame()
+        setupClickOutsideMonitor()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateDockFrame),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        if let observer = axObserver {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .commonModes)
+        }
+        if let clickMonitor = clickMonitor {
+            NSEvent.removeMonitor(clickMonitor)
+        }
+        NotificationCenter.default.removeObserver(self)
+        stopMouseTimer()
+        hidePreview()
+    }
+
+    private func setupDockObserver() {
+        guard let dockApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.dock").first else { return }
+        dockPID = dockApp.processIdentifier
+        let dockElement = AXUIElementCreateApplication(dockPID)
+
+        var children: AnyObject?
+        guard AXUIElementCopyAttributeValue(dockElement, kAXChildrenAttribute as CFString, &children) == .success,
+              let dockChildren = children as? [AXUIElement],
+              let axList = dockChildren.first(where: { $0.role() == kAXListRole }) else { return }
+
+        var observer: AXObserver?
+        let callback: AXObserverCallback = { observer, element, notification, refcon in
+            guard let refcon = refcon else { return }
+            let monitor = Unmanaged<DockIconHoverMonitor>.fromOpaque(refcon).takeUnretainedValue()
+            DispatchQueue.main.async {
+                monitor.handleDockSelectionChange()
+            }
+        }
+
+        if AXObserverCreate(dockPID, callback, &observer) == .success, let observer = observer {
+            axObserver = observer
+            let refcon = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+            AXObserverAddNotification(observer, axList, kAXSelectedChildrenChangedNotification as CFString, refcon)
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .commonModes)
+        }
+    }
+
+    @objc
+    private func updateDockFrame() {
+        guard let dockInfoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else { return }
+        for info in dockInfoList {
+            if let ownerName = info[kCGWindowOwnerName as String] as? String,
+               ownerName == "Dock",
+               let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
+               let x = bounds["X"], let y = bounds["Y"], let w = bounds["Width"], let h = bounds["Height"] {
+                dockFrame = CGRect(x: x, y: y, width: w, height: h)
+                return
+            }
+        }
+        if let screen = NSScreen.screens.first {
+            let height: CGFloat = 80
+            let visibleFrame = screen.visibleFrame
+            let fullFrame = screen.frame
+            let dockHeight = fullFrame.height - visibleFrame.height
+            if dockHeight > 0 {
+                dockFrame = CGRect(x: visibleFrame.origin.x, y: visibleFrame.origin.y + visibleFrame.height, width: visibleFrame.width, height: dockHeight)
+            } else {
+                dockFrame = CGRect(x: visibleFrame.origin.x, y: visibleFrame.origin.y, width: visibleFrame.width, height: height)
+            }
+        }
+    }
+
+    private func setupClickOutsideMonitor() {
+        clickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]) { [weak self] event in
+            self?.handleMouseAndHideIfNeeded()
+        }
+    }
+
+    private func startMouseTimer() {
+        stopMouseTimer()
+        mouseTimer = Timer.scheduledTimer(withTimeInterval: 0.045, repeats: true) { [weak self] _ in
+            self?.checkMouseAndDismissIfNeeded()
+        }
+    }
+
+    private func stopMouseTimer() {
+        mouseTimer?.invalidate()
+        mouseTimer = nil
+    }
+
+    private func checkMouseAndDismissIfNeeded() {
+        let mouseLocation = NSEvent.mouseLocation
+        let isInPopup = previewPanel?.frame.contains(mouseLocation) ?? false
+        let isOverDockIcon = isMouseOverDockIcon()
+        if !isInPopup && !isOverDockIcon {
+            hidePreview()
+        }
+    }
+
+    private func isMouseOverDockIcon() -> Bool {
+        guard let dockApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.dock").first else { return false }
+        let dockElement = AXUIElementCreateApplication(dockApp.processIdentifier)
+        var children: AnyObject?
+        guard AXUIElementCopyAttributeValue(dockElement, kAXChildrenAttribute as CFString, &children) == .success,
+              let dockChildren = children as? [AXUIElement],
+              let axList = dockChildren.first(where: { $0.role() == kAXListRole }) else { return false }
+        var selectedChildren: AnyObject?
+        guard AXUIElementCopyAttributeValue(axList, kAXSelectedChildrenAttribute as CFString, &selectedChildren) == .success,
+              let selectedList = selectedChildren as? [AXUIElement], !selectedList.isEmpty else { return false }
+        return true
+    }
+
+    private func handleMouseAndHideIfNeeded() {
+        let mouseLocation = NSEvent.mouseLocation
+        let isInPopup = previewPanel?.frame.contains(mouseLocation) ?? false
+        let isOverDockIcon = isMouseOverDockIcon()
+        if !isInPopup && !isOverDockIcon {
+            hidePreview()
+        }
+    }
+
+    func handleDockSelectionChange() {
+        guard let hoveredIcon = getCurrentlySelectedDockIcon() else {
+            lastBundleIdentifier = nil
+            hidePreview()
+            lastPanelFrame = nil
+            lastIconFrame = nil
+            return
+        }
+        guard let (iconFrame, bundleIdentifier) = getDockIconInfo(element: hoveredIcon) else {
+            lastBundleIdentifier = nil
+            hidePreview()
+            lastPanelFrame = nil
+            lastIconFrame = nil
+            return
+        }
+        guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
+            hidePreview()
+            lastPanelFrame = nil
+            lastIconFrame = nil
+            return
+        }
+
+        let windowTitles = fetchWindowTitles(for: app)
+        if windowTitles.isEmpty {
+            hidePreview()
+            lastPanelFrame = nil
+            lastIconFrame = nil
+            return
+        }
+
+        let appName = app.localizedName ?? bundleIdentifier
+        let appIcon = app.icon ?? NSWorkspace.shared.icon(forFileType: NSFileTypeForHFSTypeCode(OSType(kGenericApplicationIcon)))
+
+        let panelWidth: CGFloat = 280
+        let panelHeight = CGFloat(82 + max(24, windowTitles.count * 32))
+        let panelRect: CGRect
+        if let lastIconFrame = lastIconFrame, let lastPanelFrame = lastPanelFrame {
+            if iconFrame.equalTo(lastIconFrame) {
+                panelRect = CGRect(origin: lastPanelFrame.origin, size: CGSize(width: panelWidth, height: panelHeight))
+            } else {
+                panelRect = CGRect(x: iconFrame.midX - panelWidth/2, y: iconFrame.maxY + 10, width: panelWidth, height: panelHeight)
+                self.lastIconFrame = iconFrame
+                self.lastPanelFrame = panelRect
+            }
+        } else {
+            panelRect = CGRect(x: iconFrame.midX - panelWidth/2, y: iconFrame.maxY + 10, width: panelWidth, height: panelHeight)
+            self.lastIconFrame = iconFrame
+            self.lastPanelFrame = panelRect
+        }
+
+        let newContent = DockPreviewPanel(
+            appName: appName,
+            appIcon: appIcon,
+            windowTitles: windowTitles,
+            onTitleClick: { [weak self] title in
+                self?.focusWindow(of: app, withTitle: title)
+            }
+        )
+
+        if let panel = previewPanel, let hosting = hostingView {
+            hosting.rootView = newContent
+            panel.setContentSize(panelRect.size)
+            panel.setFrameOrigin(panelRect.origin)
+        } else {
+            let hosting = NSHostingView(rootView: newContent)
+            let panel = NSPanel(contentRect: panelRect,
+                                styleMask: [.borderless, .nonactivatingPanel],
+                                backing: .buffered, defer: false)
+            panel.contentView = hosting
+            panel.isFloatingPanel = true
+            panel.level = .statusBar
+            panel.backgroundColor = .clear
+            panel.hasShadow = false
+            panel.ignoresMouseEvents = false
+            panel.hidesOnDeactivate = false
+            panel.becomesKeyOnlyIfNeeded = true
+            panel.worksWhenModal = true
+            panel.isReleasedWhenClosed = false
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            panel.setFrameOrigin(panelRect.origin)
+            panel.setContentSize(panelRect.size)
+            panel.orderFrontRegardless()
+            self.previewPanel = panel
+            self.hostingView = hosting
+        }
+        startMouseTimer()
+    }
+
+    private func hidePreview() {
+        stopMouseTimer()
+        if let panel = previewPanel {
+            panel.orderOut(nil)
+        }
+        previewPanel = nil
+        hostingView = nil
+        lastPanelFrame = nil
+        lastIconFrame = nil
+    }
+
+    private func getCurrentlySelectedDockIcon() -> AXUIElement? {
+        guard let dockApp = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.dock").first else { return nil }
+        let dockElement = AXUIElementCreateApplication(dockApp.processIdentifier)
+        var children: AnyObject?
+        guard AXUIElementCopyAttributeValue(dockElement, kAXChildrenAttribute as CFString, &children) == .success,
+              let dockChildren = children as? [AXUIElement],
+              let axList = dockChildren.first(where: { $0.role() == kAXListRole }) else { return nil }
+        var selectedChildren: AnyObject?
+        guard AXUIElementCopyAttributeValue(axList, kAXSelectedChildrenAttribute as CFString, &selectedChildren) == .success,
+              let selectedList = selectedChildren as? [AXUIElement], !selectedList.isEmpty else { return nil }
+        let hoveredDockIcon = selectedList.first
+        if hoveredDockIcon?.subrole() == "AXApplicationDockItem" {
+            return hoveredDockIcon
+        }
+        return nil
+    }
+
+    private func getDockIconInfo(element: AXUIElement) -> (CGRect, String)? {
+        var positionValue: AnyObject?
+        var sizeValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success else { return nil }
+        var pos = CGPoint.zero, sz = CGSize.zero
+        AXValueGetValue(positionValue as! AXValue, .cgPoint, &pos)
+        AXValueGetValue(sizeValue as! AXValue, .cgSize, &sz)
+        let screenHeight = NSScreen.screens.first?.frame.height ?? 0
+        let correctedY = screenHeight - pos.y - sz.height
+        let frame = CGRect(x: pos.x, y: correctedY, width: sz.width, height: sz.height)
+
+        var bundleURL: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXURLAttribute as CFString, &bundleURL) == .success,
+              let url = bundleURL as? NSURL,
+              let bundle = Bundle(url: url as URL),
+              let bundleID = bundle.bundleIdentifier
+        else { return nil }
+        return (frame, bundleID)
+    }
+
+    private func fetchWindowTitles(for app: NSRunningApplication?) -> [String] {
+        guard let app = app else { return [] }
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var windowsValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement] else { return [] }
+        var titles: [String] = []
+        for window in windows {
+            var titleValue: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+               let title = titleValue as? String {
+                titles.append(title)
+            }
+        }
+        return titles
+    }
+
+    // Restore minimized window if needed, focus and bring to front, update DockClickMonitor counter
+    private func focusWindow(of app: NSRunningApplication?, withTitle title: String) {
+        guard let app = app else { return }
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+        var windowsValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement] else { return }
+        for window in windows {
+            var titleValue: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+               let t = titleValue as? String, t == title {
+                // Check if minimized
+                var minimizedValue: AnyObject?
+                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimizedValue) == .success,
+                   let isMinimized = minimizedValue as? Bool, isMinimized
+                {
+                    WindowManager.restoreMinimizedWindows(for: app)
+                    // Always sync counter after restoring a window
+                    dockClickMonitor?.syncAppClickCountWithWindowState(pid: app.processIdentifier)
+                }
+                // Focus window as usual
+                AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
+                AXUIElementSetAttributeValue(window, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+                app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+                return
+            }
+        }
+        app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+    }
+}

--- a/Sources/DockPreviewPanel.swift
+++ b/Sources/DockPreviewPanel.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+// Use this for the popup's background and gray lightning border, exactly as DockDoor does.
+struct BlurView: View {
+    var body: some View {
+        Rectangle().fill(.ultraThinMaterial)
+    }
+}
+
+struct DockPreviewPanel: View {
+    let appName: String
+    let appIcon: NSImage
+    let windowTitles: [String]
+    let onTitleClick: (String) -> Void
+
+    @State private var hoveredIndex: Int? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                Image(nsImage: appIcon)
+                    .resizable()
+                    .frame(width: 40, height: 40)
+                    .cornerRadius(10)
+                    .shadow(color: .black.opacity(0.18), radius: 3, x: 0, y: 1)
+                Text(appName)
+                    .font(.system(size: 19, weight: .semibold, design: .rounded))
+                    .foregroundColor(Color.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+            }
+            .padding(.bottom, 4)
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(windowTitles.enumerated()), id: \.offset) { idxTitle in
+                    let index = idxTitle.offset
+                    let title = idxTitle.element
+                    Button(action: {
+                        onTitleClick(title)
+                    }) {
+                        HStack {
+                            Text(title.isEmpty ? "(Untitled)" : title)
+                                .font(.system(size: 15, weight: .medium, design: .rounded))
+                                .foregroundColor(Color.primary)
+                                .lineLimit(1)
+                            Spacer()
+                        }
+                        .padding(.vertical, 7)
+                        .padding(.horizontal, 10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(hoveredIndex == index ? Color.accentColor.opacity(0.18) : Color.clear)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        hoveredIndex = hovering ? index : nil
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .dockStyle(cornerRadius: 18, highlightColor: nil) // <- the DockDoor look!
+        .frame(minWidth: 240, maxWidth: 320)
+        .animation(.snappy(duration: 0.13), value: hoveredIndex)
+    }
+}
+
+// --- DockDoor's border, shadow, and blur modifier ("lightning border") ---
+struct DockStyleModifier: ViewModifier {
+    let cornerRadius: Double
+    let highlightColor: Color?
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                ZStack {
+                    BlurView()
+                    if let hc = highlightColor {
+                        // Optional highlight gradient, usually not used for basic popup
+                        LinearGradient(gradient: Gradient(colors: [hc, hc.opacity(0.5)]), startPoint: .top, endPoint: .bottom)
+                            .opacity(0.2)
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .overlay {
+                    // Lightning gray border
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(Color.gray.opacity(0.19), lineWidth: 1)
+                        .blendMode(.plusLighter)
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+                }
+            }
+            .padding(2)
+    }
+}
+
+extension View {
+    func dockStyle(cornerRadius: Double = 19, highlightColor: Color? = nil) -> some View {
+        modifier(DockStyleModifier(cornerRadius: cornerRadius, highlightColor: highlightColor))
+    }
+}

--- a/Sources/DockPreviewPanel.swift
+++ b/Sources/DockPreviewPanel.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-// Use this for the popup's background and gray lightning border, exactly as DockDoor does.
 struct BlurView: View {
     var body: some View {
         Rectangle().fill(.ultraThinMaterial)
@@ -65,13 +64,12 @@ struct DockPreviewPanel: View {
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 16)
-        .dockStyle(cornerRadius: 18, highlightColor: nil) // <- the DockDoor look!
+        .dockStyle(cornerRadius: 18, highlightColor: nil)
         .frame(minWidth: 240, maxWidth: 320)
         .animation(.snappy(duration: 0.13), value: hoveredIndex)
     }
 }
 
-// macOS-style minimized indicator rhombus/diamond
 struct MinimizedIndicator: View {
     var body: some View {
         GeometryReader { geo in
@@ -84,7 +82,7 @@ struct MinimizedIndicator: View {
                 path.addLine(to: CGPoint(x: 0, y: mid))
                 path.closeSubpath()
             }
-            .fill(Color.secondary)
+            .stroke(Color.secondary, lineWidth: 1.9)
         }
         .frame(width: 12, height: 12)
         .help("This window is minimized")

--- a/Sources/MenuBarContentView.swift
+++ b/Sources/MenuBarContentView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct MenuBarContentView: View {
     @AppStorage(WindowManager.restoreAllKey) var restoreAllWindows: Bool = true
 
+    // Add onOpenSettings closure as parameter
+    var onOpenSettings: (() -> Void)? = nil
+
     var body: some View {
         VStack(spacing: 16) {
             Text("TabLift")
@@ -14,7 +17,12 @@ struct MenuBarContentView: View {
             .toggleStyle(SwitchToggleStyle())
 
             Button("Open Settings") {
-                NSApp.sendAction(#selector(AppDelegate.showUI), to: nil, from: nil)
+                // Call the closure if provided, otherwise fallback
+                if let onOpenSettings {
+                    onOpenSettings()
+                } else {
+                    NSApp.sendAction(#selector(AppDelegate.showUI), to: nil, from: nil)
+                }
             }
 
             WavyDivider()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -18,12 +18,12 @@ struct SettingsView: View {
 }
 
 struct GeneralSettingsTab: View {
-    @AppStorage(WindowManager.restoreAllKey) var restoreAllWindows: Bool = true
+    @AppStorage(WindowManager.restoreAllKey) var restoreAllWindows: Bool = false
     @AppStorage(WindowManager.openWindowKey) var openNewWindow: Bool = true
-    @AppStorage(WindowManager.minimizePreviousWindowKey) var minimizePreviousWindow: Bool = true
+    @AppStorage(WindowManager.minimizePreviousWindowKey) var minimizePreviousWindow: Bool = false
     @AppStorage("showMenuBarIcon") var showMenuBarIcon: Bool = true
     @AppStorage("startAtLogin") var startAtLogin: Bool = true
-    @AppStorage("showDockIcon") var showDockIcon: Bool = true
+    @AppStorage("showDockIcon") var showDockIcon: Bool = false
     @State private var isHoveringQuit = false
 
     private let copyright = "AGPL-3.0 © Mihai-Eduard Ghețu"

--- a/Sources/TabLiftApp.swift
+++ b/Sources/TabLiftApp.swift
@@ -18,7 +18,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var cmdBacktickMonitor: CmdBacktickMonitor?
     var window: NSWindow?
     private let autoUpdateManager = AutoUpdateManager.shared
-
+    
+    var dockClickMonitor: DockClickMonitor?
+    
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: [
             "showMenuBarIcon": true,
@@ -44,7 +46,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         appMonitor = AppMonitor()
         appMonitor?.setupEventTap()
         registerLoginItemIfNeeded()
-
+        
+        dockClickMonitor = DockClickMonitor()
+        
         let showMenuBar = UserDefaults.standard.bool(forKey: "showMenuBarIcon")
         MenuBarManager.shared.showMenuBarIcon(show: showMenuBar)
     }

--- a/Sources/TabLiftApp.swift
+++ b/Sources/TabLiftApp.swift
@@ -20,7 +20,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private let autoUpdateManager = AutoUpdateManager.shared
     
     var dockClickMonitor: DockClickMonitor?
-    
+    var dockIconHoverMonitor: DockIconHoverMonitor?  // <-- Add this property
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         UserDefaults.standard.register(defaults: [
             "showMenuBarIcon": true,
@@ -48,6 +49,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         registerLoginItemIfNeeded()
         
         dockClickMonitor = DockClickMonitor()
+        dockIconHoverMonitor = DockIconHoverMonitor() // <-- Initialize here
         
         let showMenuBar = UserDefaults.standard.bool(forKey: "showMenuBarIcon")
         MenuBarManager.shared.showMenuBarIcon(show: showMenuBar)

--- a/Sources/WindowManager.swift
+++ b/Sources/WindowManager.swift
@@ -23,7 +23,24 @@ class WindowManager {
         }
     }
 
-    private static func hasAnyPracticalVisibleWindow(for app: NSRunningApplication) -> Bool {
+    static func areAllWindowsMinimized(for app: NSRunningApplication) -> Bool {
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        if AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) != .success {
+            return false
+        }
+        guard let windows = raw as? [AXUIElement], !windows.isEmpty else { return false }
+        for window in windows {
+            var minRaw: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+               let isMin = minRaw as? Bool, !isMin {
+                return false
+            }
+        }
+        return true
+    }
+
+    static func hasAnyPracticalVisibleWindow(for app: NSRunningApplication) -> Bool {
         if hasAXVisibleWindow(for: app) { return true }
         if hasCGVisibleWindow(for: app) { return true }
         return false

--- a/Sources/WindowManager.swift
+++ b/Sources/WindowManager.swift
@@ -1,93 +1,135 @@
 import Cocoa
+import ApplicationServices
 
 class WindowManager {
-    static let restoreAllKey = "restoreAllWindows"
-    static let openWindowKey = "openNewWindow"
+    static let restoreAllKey             = "restoreAllWindows"
+    static let openWindowKey             = "openNewWindow"
     static let minimizePreviousWindowKey = "minimizePreviousWindow"
+
+    static func checkForWindows(current: NSRunningApplication, previous: NSRunningApplication?) {
+        let openNew   = UserDefaults.standard.bool(forKey: openWindowKey)
+        let minimize  = UserDefaults.standard.bool(forKey: minimizePreviousWindowKey)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            if openNew && !hasAnyPracticalVisibleWindow(for: current) {
+                openNewWindowApp(for: current)
+                return
+            }
+
+            if minimize, let prev = previous {
+                minimizeFocusedWindow(of: prev)
+            }
+            restoreMinimizedWindows(for: current)
+        }
+    }
+
+    private static func hasAnyPracticalVisibleWindow(for app: NSRunningApplication) -> Bool {
+        if hasAXVisibleWindow(for: app) { return true }
+        if hasCGVisibleWindow(for: app) { return true }
+        return false
+    }
+
+    private static func hasAXVisibleWindow(for app: NSRunningApplication) -> Bool {
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        if AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) != .success {
+            return false
+        }
+        guard let windows = raw as? [AXUIElement] else { return false }
+        for window in windows {
+            var minRaw: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+               let isMin = minRaw as? Bool, isMin {
+                continue
+            }
+            var posRaw: AnyObject?
+            var sizeRaw: AnyObject?
+            if AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRaw) == .success,
+               AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRaw) == .success {
+                let pos = posRaw as! AXValue
+                let size = sizeRaw as! AXValue
+                var position: CGPoint = .zero
+                var sz: CGSize = .zero
+                if AXValueGetType(pos) == .cgPoint,
+                   AXValueGetType(size) == .cgSize,
+                   AXValueGetValue(pos, .cgPoint, &position),
+                   AXValueGetValue(size, .cgSize, &sz),
+                   sz.width > 100, sz.height > 100
+                {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static func hasCGVisibleWindow(for app: NSRunningApplication) -> Bool {
+        guard let bundleID = app.bundleIdentifier else { return false }
+        let appProcs = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        let pids = Set(appProcs.map { $0.processIdentifier })
+
+        guard let infoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        for dict in infoList {
+            guard
+                let ownerPID = dict[kCGWindowOwnerPID as String] as? pid_t,
+                pids.contains(ownerPID),
+                let layer = dict[kCGWindowLayer as String] as? Int, layer == 0,
+                let bounds = dict[kCGWindowBounds as String] as? [String: Any],
+                let width  = bounds["Width"]  as? CGFloat, width  > 100,
+                let height = bounds["Height"] as? CGFloat, height > 100,
+                let alpha = dict[kCGWindowAlpha as String] as? CGFloat, alpha > 0.05
+            else { continue }
+            return true
+        }
+        return false
+    }
 
     static func restoreMinimizedWindows(for app: NSRunningApplication) {
         let restoreAll = UserDefaults.standard.bool(forKey: restoreAllKey)
-        let appElement = AXUIElementCreateApplication(app.processIdentifier)
-        var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-              let windows = value as? [AXUIElement] else { return }
-
-        if restoreAll {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                }
-            }
-        } else {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
-                    break
-                }
-            }
+        let appEl      = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        guard AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) == .success,
+              let windows = raw as? [AXUIElement] else {
+            return
+        }
+        for win in windows {
+            var minRaw: AnyObject?
+            guard AXUIElementCopyAttributeValue(win, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+                  let isMin = minRaw as? Bool, isMin else { continue }
+            AXUIElementSetAttributeValue(win, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+            if !restoreAll { break }
         }
     }
 
     static func minimizeFocusedWindow(of app: NSRunningApplication) {
-        let appElement = AXUIElementCreateApplication(app.processIdentifier)
         let restoreAll = UserDefaults.standard.bool(forKey: restoreAllKey)
-        var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-              let windows = value as? [AXUIElement] else { return }
-        if restoreAll {
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   !isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-                }
-            }
-        }else{
-            for window in windows {
-                var minimized: AnyObject?
-                if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                   let isMinimized = minimized as? Bool,
-                   !isMinimized {
-                    AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
-                    break
-                }
-            }
+        let appEl      = AXUIElementCreateApplication(app.processIdentifier)
+        var raw: AnyObject?
+        guard AXUIElementCopyAttributeValue(appEl, kAXWindowsAttribute as CFString, &raw) == .success,
+              let windows = raw as? [AXUIElement] else {
+            return
         }
-    }
-
-    static func checkForWindows(current: NSRunningApplication, previous: NSRunningApplication?){
-        let openNewWindow = UserDefaults.standard.bool(forKey: openWindowKey)
-        let minimizePreviousWindow = UserDefaults.standard.bool(forKey: minimizePreviousWindowKey)
-        if openNewWindow {
-            let appElement = AXUIElementCreateApplication(current.processIdentifier)
-            var value: AnyObject?
-            if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-               let windows = value as? [AXUIElement],
-               windows.isEmpty {
-                openNewWindowApp(for: current)
-                return
-            }
+        for win in windows {
+            var minRaw: AnyObject?
+            guard AXUIElementCopyAttributeValue(win, kAXMinimizedAttribute as CFString, &minRaw) == .success,
+                  let isMin = minRaw as? Bool, !isMin else { continue }
+            AXUIElementSetAttributeValue(win, kAXMinimizedAttribute as CFString, kCFBooleanTrue)
+            if !restoreAll { break }
         }
-        if minimizePreviousWindow, let previous = previous {
-            minimizeFocusedWindow(of: previous)
-        }
-        restoreMinimizedWindows(for: current)
     }
 
     private static func openNewWindowApp(for app: NSRunningApplication) {
         app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
-        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x2D, keyDown: true)
-        keyDown?.flags = .maskCommand
-        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x2D, keyDown: false)
-        keyUp?.flags = .maskCommand
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
+        let keyCode: CGKeyCode = 0x2D
+        guard let src = CGEventSource(stateID: .hidSystemState) else { return }
+        let down = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true)!
+        down.flags = .maskCommand
+        let up   = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)!
+        up.flags = .maskCommand
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
     }
 }

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -19,7 +19,10 @@
 		BE5209D92E1185CF0048CC49 /* FormViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209D82E1185CF0048CC49 /* FormViewModifier.swift */; };
 		BE5209E92E1189E80048CC49 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209E82E1189E80048CC49 /* SettingsView.swift */; };
 		BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209EA2E11A1270048CC49 /* TabLift.swift */; };
-		BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */; };
+		BE5A39C12E3A31D100146065 /* DockIconHoverMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39C02E3A31C600146065 /* DockIconHoverMonitor.swift */; };
+		BE5A39C32E3A33CA00146065 /* AXUIElement+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39C22E3A33C700146065 /* AXUIElement+Helpers.swift */; };
+		BE5A39C52E3A387700146065 /* DockClickMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39C42E3A385F00146065 /* DockClickMonitor.swift */; };
+		BE5A39C72E3A409100146065 /* DockPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39C62E3A409000146065 /* DockPreviewPanel.swift */; };
 		BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */; };
 		BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */; };
 		BE83CD402E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */; };
@@ -43,7 +46,10 @@
 		BE5209E82E1189E80048CC49 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		BE5209EA2E11A1270048CC49 /* TabLift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLift.swift; sourceTree = "<group>"; };
 		BE5209EC2E11A2FD0048CC49 /* TabLift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TabLift.entitlements; sourceTree = "<group>"; };
-		BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockClickMonitor.swift; sourceTree = "<group>"; };
+		BE5A39C02E3A31C600146065 /* DockIconHoverMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockIconHoverMonitor.swift; sourceTree = "<group>"; };
+		BE5A39C22E3A33C700146065 /* AXUIElement+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AXUIElement+Helpers.swift"; sourceTree = "<group>"; };
+		BE5A39C42E3A385F00146065 /* DockClickMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockClickMonitor.swift; sourceTree = "<group>"; };
+		BE5A39C62E3A409000146065 /* DockPreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPreviewPanel.swift; sourceTree = "<group>"; };
 		BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermission.swift; sourceTree = "<group>"; };
 		BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionWindow.swift; sourceTree = "<group>"; };
 		BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionView.swift; sourceTree = "<group>"; };
@@ -97,7 +103,10 @@
 		BEE1EC4C2E062CD500D8CE5F /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */,
+				BE5A39C62E3A409000146065 /* DockPreviewPanel.swift */,
+				BE5A39C42E3A385F00146065 /* DockClickMonitor.swift */,
+				BE5A39C22E3A33C700146065 /* AXUIElement+Helpers.swift */,
+				BE5A39C02E3A31C600146065 /* DockIconHoverMonitor.swift */,
 				BE5209C52E1179FB0048CC49 /* CheckForUpdates.swift */,
 				BE5209E82E1189E80048CC49 /* SettingsView.swift */,
 				BEE1EC482E062CD500D8CE5F /* AppMonitor.swift */,
@@ -208,15 +217,18 @@
 				BE83CD422E0EDC8600DF73E8 /* HyperLink.swift in Sources */,
 				BE1AF66C2E131C5F00DB8C44 /* MenuBarManager.swift in Sources */,
 				BEE1EC4F2E062CD500D8CE5F /* WindowManager.swift in Sources */,
+				BE5A39C72E3A409100146065 /* DockPreviewPanel.swift in Sources */,
+				BE5A39C52E3A387700146065 /* DockClickMonitor.swift in Sources */,
 				BEB9B6592E2F523E00A7456D /* MenuBarContentView.swift in Sources */,
 				BE1AF66A2E1315D600DB8C44 /* CmdBacktickMonitor.swift in Sources */,
 				BE5209C62E117A010048CC49 /* CheckForUpdates.swift in Sources */,
 				BEE1EC502E062CD500D8CE5F /* TabLiftApp.swift in Sources */,
-				BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */,
 				BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */,
+				BE5A39C32E3A33CA00146065 /* AXUIElement+Helpers.swift in Sources */,
 				BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */,
 				BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */,
 				BE5209D92E1185CF0048CC49 /* FormViewModifier.swift in Sources */,
+				BE5A39C12E3A31D100146065 /* DockIconHoverMonitor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -371,7 +371,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -402,7 +402,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=*]" = TabLift.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.7;
+				CURRENT_PROJECT_VERSION = 1.8;
 				DEVELOPMENT_TEAM = 3VR9A5DCST;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -425,7 +425,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TabLift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/TabLift.xcodeproj/project.pbxproj
+++ b/TabLift.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BE5209D92E1185CF0048CC49 /* FormViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209D82E1185CF0048CC49 /* FormViewModifier.swift */; };
 		BE5209E92E1189E80048CC49 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209E82E1189E80048CC49 /* SettingsView.swift */; };
 		BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5209EA2E11A1270048CC49 /* TabLift.swift */; };
+		BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */; };
 		BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */; };
 		BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */; };
 		BE83CD402E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */; };
@@ -42,6 +43,7 @@
 		BE5209E82E1189E80048CC49 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		BE5209EA2E11A1270048CC49 /* TabLift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabLift.swift; sourceTree = "<group>"; };
 		BE5209EC2E11A2FD0048CC49 /* TabLift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TabLift.entitlements; sourceTree = "<group>"; };
+		BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockClickMonitor.swift; sourceTree = "<group>"; };
 		BE83CD3B2E0EDC2500DF73E8 /* AccessibilityPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermission.swift; sourceTree = "<group>"; };
 		BE83CD3D2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionWindow.swift; sourceTree = "<group>"; };
 		BE83CD3F2E0EDC5B00DF73E8 /* AccessibilityPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPermissionView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 		BEE1EC4C2E062CD500D8CE5F /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				BE5A39BC2E3A201900146065 /* DockClickMonitor.swift */,
 				BE5209C52E1179FB0048CC49 /* CheckForUpdates.swift */,
 				BE5209E82E1189E80048CC49 /* SettingsView.swift */,
 				BEE1EC482E062CD500D8CE5F /* AppMonitor.swift */,
@@ -209,6 +212,7 @@
 				BE1AF66A2E1315D600DB8C44 /* CmdBacktickMonitor.swift in Sources */,
 				BE5209C62E117A010048CC49 /* CheckForUpdates.swift in Sources */,
 				BEE1EC502E062CD500D8CE5F /* TabLiftApp.swift in Sources */,
+				BE5A39BD2E3A201D00146065 /* DockClickMonitor.swift in Sources */,
 				BE83CD3C2E0EDC2500DF73E8 /* AccessibilityPermission.swift in Sources */,
 				BE5209EB2E11A1270048CC49 /* TabLift.swift in Sources */,
 				BE83CD3E2E0EDC2E00DF73E8 /* AccessibilityPermissionWindow.swift in Sources */,


### PR DESCRIPTION
This pull request introduces significant new functionality for monitoring and interacting with macOS Dock elements. Key changes include the addition of helper methods for `AXUIElement`, a `DockClickMonitor` class to track Dock clicks and manage window states, and a `DockIconHoverMonitor` class to display hover-based previews for Dock icons.

### Accessibility and Dock Interaction Enhancements:

* **Added helper methods for `AXUIElement`:** New methods `role()`, `subrole()`, and `title()` simplify querying attributes like role, subrole, and title of accessibility elements. (`Sources/AXUIElement+Helpers.swift`, [Sources/AXUIElement+Helpers.swiftR1-R25](diffhunk://#diff-49ee29e3c7ed2e4d7c2003841f53923169ff65310eb1873d277cf358fc34aff1R1-R25))

* **Introduced `DockClickMonitor`:** Tracks Dock clicks for each app and synchronizes click counts with window states (e.g., minimizing/restoring windows). Includes event tap setup, observers for frontmost app changes, and minimized state updates. (`Sources/DockClickMonitor.swift`, [Sources/DockClickMonitor.swiftR1-R182](diffhunk://#diff-bf4b6b705bc7a1059d47c5a735f539416b31605799669dc4623d918acebd0ec0R1-R182))

* **Added `DockIconHoverMonitor`:** Displays preview panels with app and window information when hovering over Dock icons. Handles mouse events, Dock selection changes, and accessibility notifications. Includes a customizable `NSPanel` for hover previews. (`Sources/DockIconHoverMonitor.swift`, [Sources/DockIconHoverMonitor.swiftR1-R340](diffhunk://#diff-2313b5574765899d4e7c834d1047fb86012d78815e738f9ab269cf70ad962c39R1-R340))